### PR TITLE
Fix nil reference error when keys attr empty

### DIFF
--- a/lib/wp/hmac/key_cabinet.rb
+++ b/lib/wp/hmac/key_cabinet.rb
@@ -7,18 +7,20 @@ module WP
       class KeyNotFound < Exception; end
 
       class << self
-        attr_accessor :keys
-        attr_writer :lookup_block
+        attr_writer :lookup_block, :keys
 
         def add_key(id:, auth_key:)
+          keys[id] = { id: id, auth_key: auth_key }
+        end
+
+        def keys
           @keys ||= {}
-          @keys[id] = { id: id, auth_key: auth_key }
         end
 
         # This method will be called by EY::ApiHMAC. It must return
         # an object that responds to +id+ and +auth_key+
         def find_by_auth_id(id)
-          hash = lookup(id) || @keys[id]
+          hash = lookup(id) || keys[id]
           msg = 'Ensure secret keys are loaded with `HMAC::KeyCabinet.add_key`'
           fail KeyNotFound, msg if hash.nil?
           OpenStruct.new(hash)

--- a/lib/wp/hmac/version.rb
+++ b/lib/wp/hmac/version.rb
@@ -1,5 +1,5 @@
 module Wp
   module Hmac
-    VERSION = '0.2.2'
+    VERSION = '0.2.3'
   end
 end


### PR DESCRIPTION
Tidy spec
Spec shows bug
Fixed bug in key cabinet by adding own reader #keys